### PR TITLE
load.RateReporter.Score: fixed division by zero

### DIFF
--- a/load/reporter.go
+++ b/load/reporter.go
@@ -68,6 +68,9 @@ func NewRateReporter(d time.Duration) *RateReporter {
 func (r *RateReporter) Score() int64 {
 	now := time.Now().UnixNano()
 	passed := now - atomic.SwapInt64(&r.time, now)
+	if passed == 0 {
+		passed = int64(time.Nanosecond)
+	}
 	if passed < r.unit {
 		atomic.AddInt64(&r.time, -passed)
 		return atomic.LoadInt64(&r.count) * r.unit / passed

--- a/load/reporter.go
+++ b/load/reporter.go
@@ -69,7 +69,7 @@ func (r *RateReporter) Score() int64 {
 	now := time.Now().UnixNano()
 	passed := now - atomic.SwapInt64(&r.time, now)
 	if passed == 0 {
-		passed = int64(time.Nanosecond)
+		return 0
 	}
 	if passed < r.unit {
 		atomic.AddInt64(&r.time, -passed)


### PR DESCRIPTION
Theoretically, Go time is very precise and `passed` should never be zero, but I've had a zero division panic:

```
panic: runtime error: integer divide by zero
[signal 0x8 code=0x1 addr=0x80bc48 pc=0x80bc48]
goroutine 1627 [running]:
panic(0xba40a0, 0xc82000a0c0)
    /usr/local/go/src/runtime/panic.go:481 +0x3e6
path/to/project/vendor/github.com/bsm/grpclb/load.(*RateReporter).Score(0xc8201b3720, 0x7f2ddb42fd80)
    /path/to/go/src/path/to/project/vendor/github.com/bsm/grpclb/load/reporter.go:73 +0xf8
path/to/project/vendor/github.com/bsm/grpclb/load.(*RateReporter).Load(0xc8201b3720, 0x7f2ddb2061e8, 0xc821189e00, 0x1167820, 0x0, 0x0, 0x0)
    /path/to/go/src/path/to/project/vendor/github.com/bsm/grpclb/load/reporter.go:87 +0x2d
path/to/project/vendor/github.com/bsm/grpclb/grpclb_backend_v1._LoadReport_Load_Handler(0xbdb660, 0xc8201b3720, 0x7f2ddb2061e8, 0xc821189e00, 0xc820efaaf0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /path/to/go/src/path/to/project/vendor/github.com/bsm/grpclb/grpclb_backend_v1/backend.pb.go:106 +0x168
path/to/project/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc8201bc240, 0x7f2ddb206050, 0xc820b502d0, 0xc8205700f0, 0xc82018be30, 0x11398a0, 0xc821189da0, 0x0, 0x0)
    /path/to/go/src/path/to/project/vendor/google.golang.org/grpc/server.go:638 +0x1098
path/to/project/vendor/google.golang.org/grpc.(*Server).handleStream(0xc8201bc240, 0x7f2ddb206050, 0xc820b502d0, 0xc8205700f0, 0xc821189da0)
    /path/to/go/src/path/to/project/vendor/google.golang.org/grpc/server.go:796 +0x10a0
path/to/project/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc820b09360, 0xc8201bc240, 0x7f2ddb206050, 0xc820b502d0, 0xc8205700f0)
    /path/to/go/src/path/to/project/vendor/google.golang.org/grpc/server.go:449 +0xa0
created by path/to/project/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
    /path/to/go/src/path/to/project/vendor/google.golang.org/grpc/server.go:450 +0x9a
```

Probably, there's something wrong in other place, not here.