### PR TITLE
Fixed leaked backend connections (load-report fetching loops)

### DIFF
--- a/balancer/service.go
+++ b/balancer/service.go
@@ -25,6 +25,8 @@ func newService(target string, discovery Discovery, discoveryInterval, loadRepor
 		closed:  make(chan struct{}),
 	}
 	if err := s.updateBackends(); err != nil {
+		// close ALL backend connections (some of them could succeed, don't leak these):
+		_ = s.backends.Update(nil)
 		return nil, err
 	}
 


### PR DESCRIPTION
`newService` constructor could instantiate some `backend`s before failing.
Added a cleanup for this case.

Btw, it would be nice to have `backends.Close()` method, I think - `s.backends.Update(nil)` is not very obvious.