### PR TITLE
Forget balancer backend on errors (except "not implemented")

### DIFF
--- a/balancer/backend.go
+++ b/balancer/backend.go
@@ -74,7 +74,7 @@ func (b *backend) Close() error {
 }
 
 func (b *backend) handleError(err error) error {
-	errCode = grpc.Code(err)
+	errCode := grpc.Code(err)
 
 	// ignored errors:
 	if errCode == codes.Unimplemented {

--- a/balancer/backend.go
+++ b/balancer/backend.go
@@ -74,9 +74,10 @@ func (b *backend) Close() error {
 }
 
 func (b *backend) handleError(err error) error {
+	errCode = grpc.Code(err)
 
 	// ignored errors:
-	if grpc.Code(err) == codes.Unimplemented {
+	if errCode == codes.Unimplemented {
 		return nil
 	}
 
@@ -84,7 +85,7 @@ func (b *backend) handleError(err error) error {
 	grpclog.Printf("error retrieving load score for %s from %s (failures: %d): %s", b.target, b.address, b.failures, err)
 
 	// recoverable errors:
-	switch grpc.Code(err) {
+	switch errCode {
 	case
 		codes.Canceled,
 		codes.DeadlineExceeded,

--- a/balancer/backend.go
+++ b/balancer/backend.go
@@ -2,10 +2,10 @@ package balancer
 
 import (
 	"sync/atomic"
-	"time"
 
 	backendpb "github.com/bsm/grpclb/grpclb_backend_v1"
 	balancerpb "github.com/bsm/grpclb/grpclb_balancer_v1"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -19,12 +19,9 @@ type backend struct {
 	target  string
 	address string
 	score   int64
-
-	closing chan struct{}
-	closed  chan error
 }
 
-func newBackend(target, address string, queryInterval time.Duration) (*backend, error) {
+func newBackend(target, address string) (*backend, error) {
 	cc, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
@@ -36,17 +33,13 @@ func newBackend(target, address string, queryInterval time.Duration) (*backend, 
 
 		target:  target,
 		address: address,
-
-		closing: make(chan struct{}),
-		closed:  make(chan error),
 	}
 
-	if err := b.updateScore(); err != nil {
-		cc.Close()
+	if err := b.UpdateScore(); err != nil {
+		b.Close()
 		return nil, err
 	}
 
-	go b.loop(queryInterval)
 	return b, nil
 }
 
@@ -61,37 +54,19 @@ func (b *backend) Score() int64 {
 	return atomic.LoadInt64(&b.score)
 }
 
-func (b *backend) Close() error {
-	close(b.closing)
-	return <-b.closed
-}
-
-func (b *backend) loop(queryInterval time.Duration) {
-	t := time.NewTicker(queryInterval)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-b.closing:
-			b.closed <- b.cc.Close()
-			close(b.closed)
-			return
-		case <-t.C:
-			if err := b.updateScore(); err != nil {
-				grpclog.Printf("error retrieving load score for %s from %s: %s", b.target, b.address, err)
-			}
-		}
-	}
-}
-
-func (b *backend) updateScore() error {
+func (b *backend) UpdateScore() error {
 	resp, err := b.cln.Load(context.Background(), &backendpb.LoadRequest{})
 	if err != nil {
 		if grpc.Code(err) == codes.Unimplemented {
 			return nil
 		}
+		grpclog.Printf("error retrieving load score for %s from %s: %s", b.target, b.address, err)
 		return err
 	}
 	atomic.StoreInt64(&b.score, resp.Score)
 	return nil
+}
+
+func (b *backend) Close() error {
+	return b.cc.Close()
 }

--- a/balancer/backend_test.go
+++ b/balancer/backend_test.go
@@ -2,26 +2,29 @@ package balancer
 
 import (
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("backend", func() {
 
 	It("should fetch score", func() {
-		be, err := newBackend("svcname", backendA.Address())
+		subject, err := newBackend("svcname", backendA.Address(), 0)
 		Expect(err).NotTo(HaveOccurred())
-		defer be.Close()
+		defer subject.Close()
 
-		Expect(be.Score()).To(Equal(int64(10)))
+		Expect(subject.Score()).To(Equal(int64(10)))
 	})
 
 	It("should ignore scores on services that don't implement score reporting", func() {
-		be, err := newBackend("svcname", backendX.Address())
+		subject, err := newBackend("svcname", backendX.Address(), 0)
 		Expect(err).NotTo(HaveOccurred())
-		defer be.Close()
-		Expect(be.Score()).To(Equal(int64(0)))
+		defer subject.Close()
+
+		Expect(subject.Score()).To(Equal(int64(0)))
 	})
 
 	It("should return load score error", func() {
@@ -30,10 +33,70 @@ var _ = Describe("backend", func() {
 
 		server.loadErr = grpc.ErrClientConnClosing
 
-		be, err := newBackend("svcname", server.Address())
+		subject, err := newBackend("svcname", server.Address(), 0)
 		Expect(err).To(HaveOccurred())
+
 		Expect(err.Error()).To(ContainSubstring(grpc.ErrClientConnClosing.Error()))
-		Expect(be).To(BeNil())
+		Expect(subject).To(BeNil())
 	})
+
+	Context("error handling", func() {
+
+		It("should ignore Unimplemented error", func() {
+			subject, err := newBackend("svc", backendX.Address(), 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subject.Close()).To(Succeed())
+		})
+
+		It("should fail immediately on non-recoverable errors", func() {
+			server := newMockServer(0)
+			server.loadErr = grpc.Errorf(codes.Unknown, "non-recoverable error")
+			defer server.Close()
+
+			_, err := newBackend("svc", server.Address(), 0)
+			Expect(err).To(HaveOccurred())
+		})
+
+		Context("recoverable errors", func() {
+			var subject *backend
+			var server *mockServer
+
+			BeforeEach(func() {
+				server = newMockServer(0)
+
+				var err error
+				subject, err = newBackend("svc", server.Address(), 2)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(subject.Close()).To(Succeed())
+				server.Close()
+			})
+
+			DescribeTable("ignore up to max failures",
+				func(code codes.Code) {
+					server.loadErr = grpc.Errorf(code, "recoverable error")
+					Expect(subject.UpdateScore()).To(Succeed())
+					Expect(subject.UpdateScore()).NotTo(Succeed())
+				},
+				Entry("Canceled", codes.Canceled),
+				Entry("DeadlineExceeded", codes.DeadlineExceeded),
+				Entry("ResourceExhausted", codes.ResourceExhausted),
+				Entry("FailedPrecondition", codes.FailedPrecondition),
+				Entry("Aborted", codes.Aborted),
+			)
+
+			It("should clear failures on success", func() {
+				server.loadErr = grpc.Errorf(codes.Aborted, "recoverable error")
+				Expect(subject.UpdateScore()).To(Succeed())
+
+				server.loadErr = nil
+				Expect(subject.UpdateScore()).To(Succeed())
+			})
+
+		}) // end recoverable errors context
+
+	}) // end error handling context
 
 })

--- a/balancer/backends.go
+++ b/balancer/backends.go
@@ -25,17 +25,21 @@ func (s strset) Contains(v string) bool {
 // --------------------------------------------------------------------
 
 type backends struct {
-	target string
-	set    map[string]*backend
-	mu     sync.RWMutex
+	target      string
+	maxFailures int
+
+	set map[string]*backend
+	mu  sync.RWMutex
 
 	closing, closed chan struct{}
 }
 
-func newBackends(target string, queryInterval time.Duration) *backends {
+func newBackends(target string, queryInterval time.Duration, maxFailures int) *backends {
 	b := &backends{
-		target: target,
-		set:    make(map[string]*backend),
+		target:      target,
+		maxFailures: maxFailures,
+
+		set: make(map[string]*backend),
 
 		closing: make(chan struct{}),
 		closed:  make(chan struct{}),
@@ -113,7 +117,7 @@ func (b *backends) connectAll(addrs []string) (err error) {
 }
 
 func (b *backends) connect(addr string) error {
-	backend, err := newBackend(b.target, addr)
+	backend, err := newBackend(b.target, addr, b.maxFailures)
 	if err != nil {
 		return err
 	}

--- a/balancer/backends_test.go
+++ b/balancer/backends_test.go
@@ -14,7 +14,7 @@ var _ = Describe("backends", func() {
 	var subject *backends
 
 	BeforeEach(func() {
-		subject = newBackends("svcname", time.Minute)
+		subject = newBackends("svcname", time.Minute, 0)
 		err := subject.Update(toStrset([]string{backendA.Address(), backendB.Address()}))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(subject.set).To(HaveLen(2))

--- a/balancer/config.go
+++ b/balancer/config.go
@@ -18,6 +18,11 @@ type Config struct {
 		// Interval between service load pings
 		// Default: 5s
 		Interval time.Duration
+		// MaxFailures allows up to this number of failures for backend
+		// before removing it from set of backends for service.
+		// Negative or zero value ignores failures completely.
+		// Default: 0 (ignore failures)
+		MaxFailures int
 	}
 }
 

--- a/balancer/config.go
+++ b/balancer/config.go
@@ -21,7 +21,7 @@ type Config struct {
 		// MaxFailures allows up to this number of failures for backend
 		// before removing it from set of backends for service.
 		// Negative or zero value ignores failures completely.
-		// Default: 0 (ignore failures)
+		// Default: 3
 		MaxFailures int
 	}
 }
@@ -35,6 +35,9 @@ func (c *Config) norm() *Config {
 	}
 	if c.LoadReport.Interval == 0 {
 		c.LoadReport.Interval = 5 * time.Second
+	}
+	if c.LoadReport.MaxFailures == 0 {
+		c.LoadReport.MaxFailures = 3
 	}
 	return c
 }

--- a/balancer/server.go
+++ b/balancer/server.go
@@ -60,7 +60,7 @@ func (b *Server) GetServers(target string) ([]*balancerpb.Server, error) {
 	}
 
 	// Create a new service connection
-	newSvc, err := newService(target, b.discovery, b.config.Discovery.Interval, b.config.LoadReport.Interval)
+	newSvc, err := newService(target, b.discovery, b.config.Discovery.Interval, b.config.LoadReport.Interval, b.config.LoadReport.MaxFailures)
 	if err != nil {
 		return nil, err
 	}

--- a/balancer/service.go
+++ b/balancer/service.go
@@ -15,11 +15,11 @@ type service struct {
 	closing, closed chan struct{}
 }
 
-func newService(target string, discovery Discovery, discoveryInterval, loadReportInterval time.Duration) (*service, error) {
+func newService(target string, discovery Discovery, discoveryInterval, loadReportInterval time.Duration, maxFailures int) (*service, error) {
 	s := &service{
 		target:    target,
 		discovery: discovery,
-		backends:  newBackends(target, loadReportInterval),
+		backends:  newBackends(target, loadReportInterval, maxFailures),
 
 		closing: make(chan struct{}),
 		closed:  make(chan struct{}),

--- a/balancer/service.go
+++ b/balancer/service.go
@@ -26,7 +26,7 @@ func newService(target string, discovery Discovery, discoveryInterval, loadRepor
 	}
 	if err := s.updateBackends(); err != nil {
 		// close ALL backend connections (some of them could succeed, don't leak these):
-		_ = s.backends.Update(nil)
+		_ = s.backends.Close()
 		return nil, err
 	}
 
@@ -48,7 +48,7 @@ func (s *service) loop(discoveryInterval time.Duration) {
 	for {
 		select {
 		case <-s.closing:
-			_ = s.backends.Update(nil)
+			_ = s.backends.Close()
 			close(s.closed)
 			return
 		case <-t.C:

--- a/balancer/service_test.go
+++ b/balancer/service_test.go
@@ -13,7 +13,7 @@ var _ = Describe("service", func() {
 
 	BeforeEach(func() {
 		var err error
-		subject, err = newService("svcname", mockDiscovery{backendA.Address(), backendB.Address()}, time.Minute, time.Minute)
+		subject, err = newService("svcname", mockDiscovery{backendA.Address(), backendB.Address()}, time.Minute, time.Minute, 0)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/balancer/service_test.go
+++ b/balancer/service_test.go
@@ -30,7 +30,7 @@ var _ = Describe("service", func() {
 
 	It("should update backends", func() {
 		subject.discovery = mockDiscovery{backendA.Address()}
-		Expect(subject.updateBackends()).NotTo(HaveOccurred())
+		Expect(subject.updateBackends()).To(Succeed())
 
 		Expect(subject.Servers()).To(ConsistOf([]*balancerpb.Server{
 			{Address: backendA.Address(), Score: 10},


### PR DESCRIPTION
Services, that are reported by discovery service and:

- are down or going down
- go down between re-discovery (done each `backend.Config.Discovery.Interval`)
- are not gRPC services

are:

- excluded from backends for service
- not queried (repeatedly, each `backend.Config.LoadReport.Interval`) anymore

However, if discovery still returns such "bad" addresses, they will be "pinged" with load report requests each `backend.Config.Discovery.Interval`.

Services, that don't implement load score report, are still remembered/returned/queried by balancer.

Solves: https://github.com/bsm/grpclb/issues/5

---

Internal changes:

- backend load score updating is now controlled/scheduled by `backends`
- `backend.UpdateScore()` made "public" to be used by `backends`
- `backends.Close()` method added - alias for `backends.Update(nil)` to explicitly indicate "close" intent
- some test cosmetics