### PR TITLE
Balancer: sort addrs on backeds update

### DIFF
--- a/balancer/backends.go
+++ b/balancer/backends.go
@@ -157,5 +157,5 @@ func (b *backends) updateBackendScores() error {
 		}
 		succeeded = append(succeeded, addr)
 	}
-	return b.Update(succeeded)
+	return b.Update(toStrset(succeeded))
 }


### PR DESCRIPTION
Sorry, my fault. And I'm afraid it could cause balancer to work with errors.

I did just a quick "fix", but I'd suggest to accept just a `[]string` array in `backends.Update` method and do `toStrset` inside it. It shouldn't affect performance, as it's done in non-test code where `backends.Update` is called.