### PR TITLE
ruby: Client - connect lazily, on first gRPC method call

### DIFF
--- a/ruby/lib/grpclb/client.rb
+++ b/ruby/lib/grpclb/client.rb
@@ -23,8 +23,6 @@ class Grpclb::Client
         with_reconnect { client.send(meth, *a, &b) }
       end
     end
-
-    reconnect!
   end
 
   def reconnect!
@@ -39,6 +37,8 @@ class Grpclb::Client
   private
 
   def with_reconnect
+    reconnect! unless @client
+
     retries = 0
     begin
       yield


### PR DESCRIPTION
Now it `reconnect!`-s in constructor, which is not very convenient for testing, like:

```ruby
module Services
  def my_service
    @my_service ||= Grpclb::Client.new(...)
  end
end
```

then:

```ruby
allow(Services.my_service).to receive(:my_grpc_method).with(...).and_return(...)
```

This fails, as call to `Services.my_service` tries to connect.
Lazy connect will allow such usage in tests.