### PR TITLE
Fix initial .client reference

### DIFF
--- a/grpclb.gemspec
+++ b/grpclb.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name          = 'grpclb'
   s.summary       = 'grpclb ruby protocol'
-  s.version       = '0.4.4'
+  s.version       = '0.4.5'
   s.authors       = ['Black Square Media']
   s.platform      = Gem::Platform::RUBY
   s.files         = `git ls-files ruby`.split("\n")

--- a/ruby/lib/grpclb/client.rb
+++ b/ruby/lib/grpclb/client.rb
@@ -36,9 +36,11 @@ class Grpclb::Client
 
   private
 
-  def with_reconnect
-    reconnect! unless @client
+  def client
+    @client || reconnect!
+  end
 
+  def with_reconnect
     retries = 0
     begin
       yield


### PR DESCRIPTION
With lazy connect client is not defined at the initial gRPC method call, so it fails.
Introduced by https://github.com/bsm/grpclb/pull/20 , sorry.